### PR TITLE
adicionar mymcplus e testar interação com PSU e VMCs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "src/memcardrex"]
 	path = src/memcardrex
 	url = https://github.com/NewsInside/memcardrex.git
+[submodule "src/mymcplus"]
+	path = src/mymcplus
+	url = https://github.com/thestr4ng3r/mymcplus.git

--- a/bin/ps2/snesstation/new/v0.2.6c_fix_Pinguinoctis/Documentação/NanoJPEG License.txt
+++ b/bin/ps2/snesstation/new/v0.2.6c_fix_Pinguinoctis/Documentação/NanoJPEG License.txt
@@ -1,0 +1,19 @@
+NanoJPEG -- KeyJ's Tiny Baseline JPEG Decoder
+version 1.3.2 (2014-02-02)
+by Martin J. Fiedler <martin.fiedler@gmx.net>
+
+This software is published under the terms of KeyJ's Research License,
+version 0.3. Usage of this software is subject to the following conditions:
+0. There's no warranty whatsoever. The author(s) of this software can not
+   be held liable for any damages that result from existence or use of this
+   software.
+1. This software may be used freely for both non-commercial and commercial
+   purposes.
+2. This software may be redistributed freely, paid or unpaid, in source or
+   binary form, standalone or as part of a larger work, as long as this
+   license information is included.
+3. This software may be modified freely except for this license information,
+   which must not be changed in any way.
+4. If anything other than configuration, indentation or comments have been
+   altered in the code, the modified code must be made accessible to the
+   original author(s).

--- a/bin/ps2/snesstation/new/v0.2.6c_fix_Pinguinoctis/Documentação/Original Readme.txt
+++ b/bin/ps2/snesstation/new/v0.2.6c_fix_Pinguinoctis/Documentação/Original Readme.txt
@@ -1,0 +1,231 @@
+                       -------  -------  -------  -------
+                      |       ||       ||       ||       |
+                      |   ---<´|.      ||.  ---< |   ---<
+                      |       ||.  |   ||.      ||       |
+                       >---   ||:  |   ||:  ---<  >---   |
+                      |::.. . ||::.|   ||::.. . ||::.. . |
+                       -------  ---^---  -------  -------
+           -------  -------  -------  -------  ---  -------  -------
+          |       ||       ||   _   ||       ||   ||   _   ||       |
+          |    --< |.|   | ||. |_|  ||.|   | ||.  ||. | |  ||.      |
+          |       | -|.  |- |.      | -|.  |- |.  ||. | |  ||.  |   |
+           >--    |  |:  |  |:  _   |  |:  |  |:  ||: |_|  ||:  |   |
+          |::.. . |  |::.|  |::| |:.|  |::.|  |::.||::.. . ||::.|   |
+           -------    ---    --   --    ---    ---  -------  ---^---
+
+                      The Super-Nintendo Emulator for PS2
+                         v0.23 WIP - 24th January 2004
+                         Written by A.Lee  (aka Hiryu)
+
+ /------------ Introduction -------------------------------------------------\
+ |                                                                           |
+ |  SNES-Station is a Super-Nintendo emulator for the PS2 Console.           |
+ |                                                                           |
+ |  It is partially based upon Snes9x written by Gary Henderson and others,  | 
+ |  but many changes and additions have been made during development.        |
+ |                                                                           |
+ |  SNES-Station is freeware and may be downloaded from                      |
+ |  http://snes-station.gamebase.ca/                                         |
+ |                                                                           |
+ |  Please do not re-distribute this program with ROMs or any other          |
+ |  copyrighted material. We do not condone such behaviour.                  |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/------------ New Features -------------------------------------------------\|
+\´                                                                            /
+ |  - Zipped ROM Support                                                     |
+ |                                                                           |
+ |  - Full State Save to Memory Card                                         |
+ |                                                                           |
+ |  - Completely New High-resolution GUI                                     |
+ |                                                                           |
+ |  - New memory card manager                                                |
+ |                                                                           |
+ |  - New In-game Menu                                                       |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Still To Do ---------------------------------------------------\|
+\´                                                                            /
+ |  - Graphics core and sound core re-writes                                 |
+ |    (to get all games playing at 100% speed)                               |
+ |                                                                           |
+ |  - Super-FX core optimisation to speed up SuperFX games                   |
+ |                                                                           |
+ |  - SDD1 Decompression to support SDD1 games                               |
+ |                                                                           |
+ |  - Proper support for High-resolution SNES games                          |
+ |                                                                           |
+ |    and more                                                               |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Creating a CD -------------------------------------------------\|
+\´                                                                            /
+ |  For help on creating a SNES-Station compilation CD please read the       |
+ |  documentation available at http://snes-station.gamebase.ca               |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Game Controls -------------------------------------------------\|
+\´                                                                            /
+ |  SNES     PS2                                                             |
+ |  ----     ---                                                             |
+ |  D-Pad    D-Pad or left analog stick                                      |
+ |  Start    Start                                                           |
+ |  Select   Select                                                          |
+ |  A        Circle                                                          |
+ |  B        Cross                                                           |
+ |  X        Triangle                                                        |
+ |  Y        Square                                                          |
+ |  L        L1 or L2 (select in menu)                                       |
+ |  R        R1 or R2 (select in menu)                                       |
+ |                                                                           |
+ |  Quit Game and Return to Menu = L1+R1 or L2+R2 (select in menu)           |
+ |                                                                           |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Menu Controls -------------------------------------------------\|
+\´                                                                            /
+ |  Use the D-PAD to scroll through the ROM List or Options Menu, one entry  |
+ |  at a time.                                                               |
+ |                                                                           |
+ |  Use the Left Analogue Stick to scroll through the ROM List at variable   |
+ |  speed.                                                                   |
+ |                                                                           |
+ |  Use R1/R2 to scroll through the ROM List at high speed.                  |
+ |                                                                           |
+ |  Use L1/L2 to jump to the top/bottom of the ROM List.                     |
+ |                                                                           |
+ |  Use X to select the current ROM or menu entry.                           |
+ |                                                                           |
+ |  Use Triangle to go to the Options menu.                                  |
+ |                                                                           |
+ |  Use Square to view the credits page.                                     |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Frequently Asked Questions ------------------------------------\|
+\´                                                                            /
+ |  1.  How do I get this to run on my Playstation 2?                        |
+ |                                                                           |
+ |      You need a way to play PS2 CD-Rs.                                    |
+ |      This either requires a modchip or another method to play PS2 CD-Rs.  |
+ |      If you do not have a modchip fitted to your PS2 console then either  |
+ |      get one, or "google" for "PS2 Knife Swap" or "PS2 Swap Trick".       |
+ |                                                                           |
+ |  2.  I downloaded all the files from the website. How do I make a cd?     |
+ |                                                                           |
+ |      There is a step-by-step guide, on http://snes-station.gamebase.ca    |
+ |                                                                           |
+ |  3.  I burned the cd but it doesn't work.  What now?                      |
+ |                                                                           |
+ |      If you want more help then visit the official forums on              |
+ |      http://www.gamebase.ca/forums                                        |
+ |                                                                           |
+ |  4.  I downloaded a bin/cue from somewhere but it doesn't work.           |
+ |      Can you help me ?                                                    |
+ |                                                                           |
+ |      No. We do not condone distribution of so-called "rompacks".          |
+ |      Please use the directions in the documentation available on the      |
+ |      SNES-Station website or forums to make your own compilation CD.      |
+ |      (with the ROMs that you legally own)                                 |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Contact -------------------------------------------------------\|
+\´                                                                            /
+ |  Comments, Feedback and any Bug Reports can be left on the SNES-Station   |
+ |  Forums, kindly hosted by Gamebase at: http://www.gamebase.ca/forums      |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Credits+Greetings ---------------------------------------------\|
+\´                                                                            /
+ |  Credits:                                                                 |
+ |  --------                                                                 |
+ |  PS2 specific code, as well as many changes to the emulation core by      |
+ |  A.Lee (Hiryu)                                                            |
+ |                                                                           |
+ |  This emulator is based on Snes9x written by Gary Henderson and others.   |
+ |                                                                           |
+ |  'gsLib' PS2 graphics library written by Hiryu (A.Lee)                    |
+ |                                                                           |
+ |  LibCDVD PS2 CD/DVD library written by Hiryu                              |
+ |                                                                           |
+ |  SjPCM sound library written by Sjeep                                     |
+ |                                                                           |
+ |  Memory card icon was designed by Nikorasu                                |
+ |                                                                           |
+ |  Menu and website graphics by Gonz0, Ragnarok and Hiryu                   |
+ |                                                                           |
+ |  Menu music "can't stop coming" was written by azazel                     |
+ |                                                                           |
+ |  PS2 kernel code based on work by Gustavo Scotti                          |
+ |                                                                           |
+ |  Joypad library by |pukko|                                                |
+ |                                                                           |
+ |                                                                           |
+ |  Thanks to:                                                               |
+ |  ----------                                                               |
+ |  My family for putting up with me spending so much time working on this   |
+ |  project.                                                                 |
+ |                                                                           |
+ |  Sjeep for SjPCM, helping out with my new CD Filing System Driver, and    |    
+ |  continued help and support                                               |
+ |                                                                           |
+ |  Nikorasu for the excellent SNES Memory Card icon                         |
+ |                                                                           |
+ |  |pukko| and others for ps2Link, and Team InPulse for InLink win32        |
+ |  which were used throughout development                                   |
+ |                                                                           |
+ |  Justice7 and the rest of the gamebase crew for hosting my website        |
+ |                                                                           |
+ |  Everyone at #ps2-emulation for all their help and support                |
+ |                                                                           |
+ |  Everyone at #ps2dev and #psx2dev for all the PS2 coding help             |
+ |                                                                           |
+ |  Bgnome and M0rphius for writing several of the SNES-Station docs         |
+ |                                                                           |
+ |  The BETA testers:                                                        |
+ |  Sjeep, HyperG, emukidid, |cloud| and justice7                            |
+ |                                                                           |
+ |                                                                           |
+ |  Greetz:                                                                  |
+ |  -------                                                                  |
+ |  Sjeep, MRBrown, Oobles, adresd, Jules, Nagra, Warren, LongChair, pukko,  |
+ |  Vzzrzzn, now3d, dreamtime, sg2, asadr, Justice7, [vex], [WaL], emukidid, |
+ |  Nikorasu, RUNTiME, and anybody that I forgot to mention                  |
+ |                                                                           |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|        ||                                                         ||        |
+|/----------- Disclaimer ----------------------------------------------------\|
+\´                                                                            /
+ |  This software is not endorsed by Sony Computer Entertainment Inc. or     |
+ |  Nintendo Inc. in any way.                                                |
+ |                                                                           |
+ |  This software is produced without the use of any copyrighted material,   |
+ |  belonging to Sony Computer Entertainment Inc, or Nintendo Inc, or any    |
+ |  other party.                                                             |
+ |                                                                           |
+ |  Companies and all products pertaining to that company are trademarks of  |
+ |  that company. Please contact the appropriate company for trademark and   |
+ |  copyright information.                                                   |
+ |                                                                           |
+ |  This software should only be used to play games which the user legally   |
+ |  owns.                                                                    |
+ |                                                                           |
+ |  This software must never be distributed with any copyrighted games       |
+ |  or other material. Any breach of these terms is out of the authors       |
+ |  control, and is not at the authors consent.                              |
+ |                                                                           |
+ |  SNES-Station is FREE software. If you bought this software, then you     |
+ |  have been ripped off.                                                    |
+/´                                                                            \
+|\---------------------------------------------------------------------------/|
+|                                                                             |
+| Text by Hiryu                                    Layout by Hiryu & MoRpHiUs |
+\-----------------------------------------------------------------------------/

--- a/bin/ps2/snesstation/new/v0.2.6c_fix_Pinguinoctis/Documentação/Release Notes.txt
+++ b/bin/ps2/snesstation/new/v0.2.6c_fix_Pinguinoctis/Documentação/Release Notes.txt
@@ -1,0 +1,33 @@
+SNES Station 0.2.6c Mod by Pinguinoctis
+
+This mod is based on Megaman SNES Station extension, since the source code of SNES Station,
+as far as I know, has never been released.
+
+Many thanks go to:
+    Hiryu, he originally wrote the SNES Station PS2 emulator, and everyone behind it.
+    Megaman, for the SNES Station extension (which this mod is based on).
+    The PCSX2 guys for making a great work with the PCSX2 Debugger in the latest dev versions (I simply love it)!
+
+Big thanks even to people that pointed out bugs/issues or gave me suggestions!
+And especially to antonioks and Morpheus SD which made an impressive package full of covers
+(9372 of them) and cheats (784 of them) to use along this mod!
+You can find it here:
+https://docs.google.com/uc?id=0B_5i7Vb-NpxMV1VQQTBQam5fVFE&export=download
+
+Release notes:
++ Fixed the bug which caused ".zip" roms to not appear. The letter "z" was excluded
+  in the comparison function, but the big "Z" still worked. So ".ZIP" roms wouldn't cause the issue.
++ Added support to PNG images for covers! If no JPG is found a PNG will be searched,
+  this means JPGs will always have the highest priority. For PNG support I've used the uPNG library.
++ No more Cheat Mode option. Now to edit cheats it's enough to press the Select button.
++ Added the possibility to return one directory back by pressing the Circle button.
++ Added the possibility to have a custom background! Both JPG and PNG images are supported.
+  They must be sized 640x480, they must be copied where the emulator ELF resides
+  and they must be named "BG.JPG" or "BG.PNG" (both lower or uppercase are fine).
++ Added an option to enable/disable background music in MISC folder.
++ Added an option to enable/disable black border on covers in MISC folder.
++ Added some options to run an external BOOT/BOOT.ELF from mc0, mass and cdfs in MISC folder.
+  I don't know how much they are stable, since I had to tweak the loading process a bit.
++ Added an option to Save (they will be saved in mc0) and Load settings in MISC folder.
+
+For issues you can contact me on my blog: https://pinguinoctis.blogspot.com/


### PR DESCRIPTION
Versão melhorada do MyMC.

A importação de savegames em PSU funciona em MemoryCards de formatos diversos - incluindo os VMCs criados pelo OPL e PCSX2.

Porém o OPL via SMB informa sobre falhas. Ao carregar um VMC criado pelo OPL, mas editado pelo MyMCPlus: o OPL simplesmente se recusa a carregar o MC. 

Abrirei uma issue sobre isso. Preciso testar o VMC editado com o uLE e o OPL via USB.